### PR TITLE
Add command line options to generate server modules independently

### DIFF
--- a/bootstrap/golang/content/scripts/generate.sh
+++ b/bootstrap/golang/content/scripts/generate.sh
@@ -7,4 +7,4 @@ go get golang.org/x/net/context/ctxhttp
 go get github.com/tylerb/graceful
 go get github.com/jessevdk/go-flags
 
-codon generate
+codon generate ${ARGS}

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -22,6 +22,12 @@ import (
 	codon_generator "github.com/grofers/go-codon/generator"
 )
 
+var (
+	generateClients		bool
+	generateWorkflow	bool
+	generateServer		bool
+)
+
 // generateCmd represents the generate command
 var generateCmd = &cobra.Command{
 	Use:   "generate",
@@ -29,9 +35,21 @@ var generateCmd = &cobra.Command{
 	Long: `After you have run init on your project folder you should edit
 the specification and configuration files according to your project. Run
 this command to finally generate code according to the specification. Your
-working directory must be your project directory.`,
+working directory must be your project directory. Not specifying any
+generator flags will generate everything.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		if codon_generator.Generate("golang") {
+		if !generateClients && !generateWorkflow && !generateServer {
+			generateClients = true
+			generateWorkflow = true
+			generateServer = true
+		}
+		opts := codon_generator.GenOpts {
+			Language: "golang",
+			GenerateClients: generateClients,
+			GenerateWorkflow: generateWorkflow,
+			GenerateServer: generateServer,
+		}
+		if codon_generator.Generate(opts) {
 			log.Println("Generate successful")
 		} else {
 			log.Println("Generate failed")
@@ -51,6 +69,7 @@ func init() {
 
 	// Cobra supports local flags which will only run when this command
 	// is called directly, e.g.:
-	// generateCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
-
+	generateCmd.Flags().BoolVarP(&generateClients, "clients", "c", false, "Generate clients")
+	generateCmd.Flags().BoolVarP(&generateWorkflow, "workflow", "w", false, "Generate workflow")
+	generateCmd.Flags().BoolVarP(&generateServer, "server", "s", false, "Generate server")
 }

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -2,21 +2,24 @@ package generator
 
 import (
 	"log"
+	"github.com/grofers/go-codon/generator/shared"
 	"github.com/grofers/go-codon/generator/golang"
 )
 
+type GenOpts shared.GenOpts
+
 type generatable interface {
-	Generate() bool
+	Generate(shared.GenOpts) bool
 }
 
 var language_map = map[string]generatable {
 	"golang": &golang.Generator,
 }
 
-func Generate(lang string) bool {
-	bs, ok := language_map[lang]
+func Generate(opts GenOpts) bool {
+	bs, ok := language_map[opts.Language]
 	if !ok {
-		log.Println("Support for language ", lang, " not implemented yet")
+		log.Println("Support for language ", opts.Language, " not implemented yet")
 	}
-	return bs.Generate()
+	return bs.Generate(shared.GenOpts(opts))
 }

--- a/generator/golang/golang.go
+++ b/generator/golang/golang.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/go-openapi/swag"
 
+	gen_shared "github.com/grofers/go-codon/generator/shared"
 	codon_shared "github.com/grofers/go-codon/shared"
 	config "github.com/grofers/go-codon/runtime/config"
 
@@ -249,7 +250,7 @@ func (gen *generator) GenerateWorkflow() bool {
 	return true
 }
 
-func (gen *generator) Generate() bool {
+func (gen *generator) Generate(opts gen_shared.GenOpts) bool {
 	gen.Init()
 	log.Println("Generating a codon project in golang ...")
 
@@ -261,20 +262,26 @@ func (gen *generator) Generate() bool {
 		return false
 	}
 
-	if !gen.GenerateUpstream() {
-		return false
+	if opts.GenerateClients {
+		if !gen.GenerateUpstream() {
+			return false
+		}
+
+		if !gen.GenerateContent() {
+			return false
+		}
 	}
 
-	if !gen.GenerateContent() {
-		return false
+	if opts.GenerateWorkflow {
+		if !gen.GenerateWorkflow() {
+			return false
+		}
 	}
 
-	if !gen.GenerateWorkflow() {
-		return false
-	}
-
-	if !gen.GenerateService() {
-		return false
+	if opts.GenerateServer {
+		if !gen.GenerateService() {
+			return false
+		}
 	}
 
 	return true

--- a/generator/shared/structs.go
+++ b/generator/shared/structs.go
@@ -1,0 +1,8 @@
+package shared
+
+type GenOpts struct {
+	Language			string
+	GenerateClients		bool
+	GenerateWorkflow	bool
+	GenerateServer		bool
+}


### PR DESCRIPTION
 Add `ARGS` variable to make file. `codon generate` command will be called using those `ARGS`.

This is done to decrease development time and quickly generate only those portions of code whose spec has been modified.